### PR TITLE
Fix issue-1 deprecated warning for block_categories filter

### DIFF
--- a/inc/hooks/change-block-category-order.php
+++ b/inc/hooks/change-block-category-order.php
@@ -11,15 +11,12 @@ namespace WebDevStudios\wd_f;
  * Change_block_category_order
  *
  * @param array   $categories An array of block categories.
- * @param WP_Post $post The post object being edited.
+ * @param WP_Block_Editor_Context $block_editor_context 	The current block editor context.
  * @return array The modified array of block categories.
  * @author JC Palmes <jc@webdevstudios.com>
  * @since 2023-06-02
  */
-function change_block_category_order( $categories, $post ) {
-	if ( 'page' !== $post->post_type ) {
-		return $categories;
-	}
+function change_block_category_order( $categories, $block_editor_context ) {
 
 	$wds_block_category = [
 		'slug'  => 'wds-blocks-category',
@@ -29,4 +26,4 @@ function change_block_category_order( $categories, $post ) {
 	array_unshift( $categories, $wds_block_category );
 	return $categories;
 }
-add_filter( 'block_categories', __NAMESPACE__ . '\change_block_category_order', 10, 2 );
+add_filter( 'block_categories_all', __NAMESPACE__ . '\change_block_category_order', 10, 2 );


### PR DESCRIPTION
Closes [issue-1](https://github.com/WebDevStudios/wd_f/issues/1)

Updated block_categories filter

Screenshot:

![image](https://github.com/WebDevStudios/wd_f/assets/22427070/481e55df-c3ed-48c5-bebb-4a88af0d59fb)

How to test?

Pull this branch and add a new page. You should not get this warning. _Deprecated: Hook block_categories is deprecated since version 5.8.0! Use block_categories_all instead._