### PR TITLE
Fix #14: Remove CSS styles for columns and navigation link block from theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -244,9 +244,6 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
-			"core/columns": {
-				"css": ".is-style-columns-reverse {@media only screen and (max-width: 780px) {flex-direction: column-reverse;}}"
-			},
 			"core/comment-author-name": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",
@@ -299,9 +296,6 @@
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
-			},
-			"core/navigation-link": {
-				"css": ".is-style-outline a {@media only screen and (min-width: 800px) {border: 1px solid currentColor;border-radius: 5px;padding: 7px 15px;}}"
 			},
 			"core/post-comments-form": {
 				"css": "& input[type=submit] {width: auto;} & label {font-size: var(--wp--preset--font-size--x-small);}"


### PR DESCRIPTION
### Description

This PR fixes #14 

A couple of custom CSS styles were added for the Columns and the Navigation Link core blocks which the block editor script was not able to compile and it was throwing error in the console.

![image](https://github.com/WebDevStudios/wd_f/assets/8023941/f903b2ea-c815-45d8-a31e-3303ee7b4805)
