### PR TITLE
Add a readme.txt with a copyright notice.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-Hey there! I'm wd_f, or WebDev FSE, and I'm here to introduce you to the exciting world of full site editing. As an experimental sister theme of wd_f, I'm designed for those who are eager to let their creativity run wild and turn me into an amazing WordPress theme. Join me on this adventure of exploration and customization, and together, let's create something truly extraordinary!
+Hey there! I'm wd_f, or WebDev FSE, and I'm here to introduce you to the exciting world of full site editing. As an experimental sister theme of wd_s, I'm designed for those who are eager to let their creativity run wild and turn me into an amazing WordPress theme. Join me on this adventure of exploration and customization, and together, let's create something truly extraordinary!
 
 == Copyright ==
 

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: wd_f
 Theme URI: https://webdevstudios.com/
 Author: WebDevStudios
 Author URI: https://webdevstudios.com/
-Description: Hey there! I'm <code>wd_f</code>, or <b>WebDev FSE</b>, and I'm here to introduce you to the exciting world of full site editing. As an experimental sister theme of <code>wd_f</code>, I'm designed for those who are eager to let their creativity run wild and turn me into an amazing WordPress theme. Join me on this adventure of exploration and customization, and together, let's create something truly extraordinary!
+Description: Hey there! I'm <code>wd_f</code>, or <b>WebDev FSE</b>, and I'm here to introduce you to the exciting world of full site editing. As an experimental sister theme of <code>wd_s</code>, I'm designed for those who are eager to let their creativity run wild and turn me into an amazing WordPress theme. Join me on this adventure of exploration and customization, and together, let's create something truly extraordinary!
 Version: 3.5.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This resolves both Issue #29 and issue #30 at the same time.

The Theme Check plugin recommended having both a copyright notice and a readme.txt. I used `twentytwentythree` as a reference and created the readme.txt for wd_f.

<img width="1631" alt="Screen Shot 2023-07-28 at 1 06 17 PM" src="https://github.com/WebDevStudios/wd_f/assets/5550150/e6999287-8ad6-4d95-992d-0131b911c56f">
